### PR TITLE
Fixed Bottle of Enchanting craft and added chest craft with logs

### DIFF
--- a/data/proxus/recipes/bottleoenchanting.json
+++ b/data/proxus/recipes/bottleoenchanting.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "type": "crafting_shaped",
     "pattern": [
         "###",
@@ -12,7 +12,7 @@
         "L": {
             "item": "minecraft:enchanted_book"
         }
-	},
+    },
     "result": {
         "item": "minecraft:experience_bottle",
         "count": 8

--- a/data/proxus/recipes/bottleoenchanting.json
+++ b/data/proxus/recipes/bottleoenchanting.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "type": "crafting_shaped",
     "pattern": [
         "###",
@@ -12,7 +12,7 @@
         "L": {
             "item": "minecraft:enchanted_book"
         }
-    },
+	},
     "result": {
         "item": "minecraft:experience_bottle",
         "count": 8

--- a/data/proxus/recipes/chest_with_logs.json
+++ b/data/proxus/recipes/chest_with_logs.json
@@ -1,0 +1,17 @@
+﻿{
+    "type": "crafting_shaped",
+    "pattern": [
+        "###",
+        "# #",
+        "###"
+    ],
+    "key": {
+        "#": {
+            "tag": "minecraft:logs"
+		}
+	},
+    "result": {
+        "item": "minecraft:chest",
+        "count": 4
+    }
+}


### PR DESCRIPTION
The chest crafted with 8 logs will give 4 chests instead of 1, you can still craft them with planks.
If someone knows how to make it so it's grouped with the original craft (same with sticks with logs), can you please make it?